### PR TITLE
Add other repos as submodules.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore submodules
+/client
+/parser
+/plugins
+/util

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,16 @@
+[submodule "client"]
+	path = client
+	url = git@github.com:DMDirc/DMDirc.git
+	branch = master
+[submodule "plugins"]
+	path = plugins
+	url = git@github.com:DMDirc/Plugins.git
+	branch = master
+[submodule "util"]
+	path = util
+	url = git@github.com:DMDirc/Util.git
+	branch = master
+[submodule "parser"]
+	path = parser
+	url = git@github.com:DMDirc/Parser.git
+	branch = master


### PR DESCRIPTION
I've added them to .gitmodules but ignored the repos themselves.
Hopefully this means everyone can just do `git submodule update
--init --remote`, without us having to commit updates every
time one of the repos changes.
