### PR TITLE
Add a script to magically change dependencies.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
+apply from: 'local-dependency-change.gradle'
+
 task createWrapper(type: Wrapper) {
     description 'Downloads and installs an up-to-date wrapper for gradle.'
     gradleVersion = '2.1'

--- a/local-dependency-change.gradle
+++ b/local-dependency-change.gradle
@@ -1,0 +1,26 @@
+gradle.projectsEvaluated {
+    def projectMap = [:]
+    allprojects.each { p -> projectMap[p.name] = p }
+
+    allprojects.each { p ->
+        def replace = []
+
+        p.configurations.each { conf ->
+            conf.dependencies.each { dep ->
+                if (dep.group == 'com.dmdirc' && dep.version == '+' && projectMap[dep.name] != null) {
+                    replace += [conf: conf.name, dep: dep]
+                }
+            }
+        }
+
+        replace.each { rep ->
+            logger.info("Replacing ${p.name}'s dependency on $rep.dep.name with project reference")
+            p.configurations.all*.exclude(group: 'com.dmdirc', module: rep.dep.name)
+            rep.dep.properties.excludeRules.each { ex ->
+                p.configurations.all*.exclude(group: ex.group, module: ex.module)
+            }
+            p.dependencies.add(rep.conf, projectMap[rep.dep.name])
+        }
+    }
+}
+


### PR DESCRIPTION
This changes any com.dmdirc.\* dependency references into
local project references.

It doesn't yet work for the parser as that's a different
group, and doesn't have independent projects.
