### PR TITLE
Add clover support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # Gradle created directories
 /.gradle
+/build
+
+# Downloaded private settings
+/etc/clover/clover.license

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,18 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+
+    dependencies {
+        classpath group: 'org.gradle.api.plugins', name: 'gradle-clover-plugin', version: '0.8.2'
+    }
+}
+
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
+apply from: 'clover.gradle'
 apply from: 'local-dependency-change.gradle'
 
 task createWrapper(type: Wrapper) {

--- a/clover.gradle
+++ b/clover.gradle
@@ -1,0 +1,33 @@
+task getCloverCredentials << {
+    def licenseDir = rootDir.toPath().resolve('etc').resolve('clover')
+    java.nio.file.Files.createDirectories(licenseDir);
+
+    def target = licenseDir.resolve('clover.license')
+    if (!java.nio.file.Files.exists(target)) {
+        println 'Attempting to download clover license...'
+        new URL('http://www.dmdirc.com/private/clover.license').withInputStream{
+            i -> target.withOutputStream { it << i }
+        }
+    }
+}
+
+allprojects {
+    apply plugin: 'clover'
+
+    clover {
+        licenseLocation = "$rootDir/etc/clover/clover.license"
+
+        report {
+            html = true
+        }
+    }
+
+    repositories.mavenCentral()
+
+    dependencies {
+        clover group: 'com.atlassian.clover', name: 'clover', version: '4.0.0'
+    }
+
+    cloverGenerateReport.dependsOn ':getCloverCredentials'
+}
+


### PR DESCRIPTION
`./gradlew clean cloverAggregateReport` in meta will create a new
report for all the projects with tests.

Plugins that don't have any tests won't show up at all.
