### PR TITLE
Temorarily disable clover haxily.

### DIFF
--- a/clover.gradle
+++ b/clover.gradle
@@ -15,6 +15,8 @@ allprojects {
     apply plugin: 'clover'
 
     clover {
+        includeTasks = ['none']
+
         licenseLocation = "$rootDir/etc/clover/clover.license"
 
         report {
@@ -29,5 +31,6 @@ allprojects {
     }
 
     cloverGenerateReport.dependsOn ':getCloverCredentials'
+
 }
 


### PR DESCRIPTION
Setting enabled=false still loads clover and expects a license,
it just doesn't instrument.

Define includeTasks so we don't include any real tasks as a
work-around for this.

Not entirely sure how to enable it again at runtime though :)
