### PR TITLE
Propagate transitivity when switching modules.

### DIFF
--- a/local-dependency-change.gradle
+++ b/local-dependency-change.gradle
@@ -10,7 +10,7 @@ gradle.projectsEvaluated {
             conf.dependencies.each { dep ->
                 if (dep.group =~ '^com.dmdirc' && dep.version == '+' && projectMap[dep.name] != null) {
                     remove += dep
-                    replace += [conf: conf.name, dep: dep]
+                    replace += [conf: conf.name, dep: dep, transitive: dep.transitive]
                 }
             }
 
@@ -18,7 +18,7 @@ gradle.projectsEvaluated {
         }
 
         replace.each { rep ->
-            p.dependencies.add(rep.conf, projectMap[rep.dep.name])
+            p.dependencies.add(rep.conf, projectMap[rep.dep.name], { transitive rep.transitive })
         }
     }
 }


### PR DESCRIPTION
Transitivity is _very_ important when we're bundling dependencies.
Without this, the IRC plugin includes all the dependencies of the
parser (including "common"), which means it ends up with its own
version of common classes and can't be called from the rest of the
client. Not having an IRC parser is... unideal. This was very
confusing, which is why the commit message is randomly 8 lines
long. But it's over now; thank you for reading.
