### PR TITLE
Update clover/plugin versions.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,6 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-
-    dependencies {
-        classpath group: 'org.gradle.api.plugins', name: 'gradle-clover-plugin', version: '0.8.2'
-    }
+plugins {
+    id 'com.bmuschko.clover' version '2.0.1'
 }
-
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 apply from: 'gradle/clover.gradle'
 apply from: 'gradle/local-dependency-change.gradle'

--- a/gradle/clover.gradle
+++ b/gradle/clover.gradle
@@ -9,7 +9,7 @@ task checkCloverCredentials << {
 }
 
 allprojects {
-    apply plugin: 'clover'
+    apply plugin: 'com.bmuschko.clover'
 
     clover {
         includeTasks = Boolean.valueOf(rootProject.enableClover) ? [] : ['none']
@@ -24,10 +24,9 @@ allprojects {
     repositories.mavenCentral()
 
     dependencies {
-        clover group: 'com.atlassian.clover', name: 'clover', version: '4.0.0'
+        clover group: 'com.atlassian.clover', name: 'clover', version: '4.0.2'
     }
 
     cloverGenerateReport.dependsOn ':checkCloverCredentials'
-
 }
 


### PR DESCRIPTION
Clover doesn't currently work due to a bug in lambda handling,
and we can't disable that with the plugin. Clover 4.0.3 should
fix this.